### PR TITLE
Fix the feature call advice

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ end
 
     <h2>Some basics</h2>
 
-    <p>The first difference you will notice in Eiffel compared to other languages like C++ or Java is the absence of curly brackets to separate code blocks. Instead in Eiffel we use keywords followed by <b>end</b>. We also do not ordinarily terminate lines of code with a semi-colon. However, it is acceptable to separate statements with a semi-colon if you so wish. Features (functions) can be called without using brackets, if they do not accept any arguments (e.g. <b>target.my_function</b> instead of <b>target.my_function()</b>).
+    <p>The first difference you will notice in Eiffel compared to other languages like C++ or Java is the absence of curly brackets to separate code blocks. Instead in Eiffel we use keywords followed by <b>end</b>. We also do not ordinarily terminate lines of code with a semi-colon. However, it is acceptable to separate statements with a semi-colon if you so wish. Features (functions) are called without using brackets, if they do not accept any arguments (e.g. <b>target.my_function</b> instead of <b>target.my_function()</b>).
 
 
 

--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ end
 
     <h2>Some basics</h2>
 
-    <p>The first difference you will notice in Eiffel compared to other languages like C++ or Java is the absence of curly brackets to separate code blocks. Instead in Eiffel we use keywords followed by <b>end</b>. We also do not ordinarily terminate lines of code with a semi-colon. However, it is acceptable to separate statements with a semi-colon if you so wish. Features (functions) can be called without using brackets, if they do not accept any arguments (Ex: <b>target.my_function</b> instead of <b>target.my_function()</b>).
+    <p>The first difference you will notice in Eiffel compared to other languages like C++ or Java is the absence of curly brackets to separate code blocks. Instead in Eiffel we use keywords followed by <b>end</b>. We also do not ordinarily terminate lines of code with a semi-colon. However, it is acceptable to separate statements with a semi-colon if you so wish. Features (functions) can be called without using brackets, if they do not accept any arguments (e.g. <b>target.my_function</b> instead of <b>target.my_function()</b>).
 
 
 


### PR DESCRIPTION
Hi!
- Fix the feature call advice. A feature with no arguments cannot be called via an empty bracket syntax.
- Fix a typo ([Ex means Exercice](http://english.stackexchange.com/questions/16197/whats-the-difference-between-e-g-and-ex))
